### PR TITLE
Fix ants weird behaviours

### DIFF
--- a/src/main/sarl/fr/utbm/info/vi51/worldswar/agent/behaviour/tactical/AntTacticalBehaviour.java
+++ b/src/main/sarl/fr/utbm/info/vi51/worldswar/agent/behaviour/tactical/AntTacticalBehaviour.java
@@ -39,12 +39,12 @@ public class AntTacticalBehaviour {
 			memory.put("pheromoneType", PheromoneType.HOME);
 			memory.put("pheromoneDistance", new Integer(0));
 		}
-		if (perception.isFoodInSight()) {
-			if (perception.getFoodAt(MY_POSITION) > 0) {
-				memory.put("pheromoneType", PheromoneType.FOOD);
-				memory.put("pheromoneDistance", new Integer(0));
-				return this.operationalBehaviour.pickFood(perception);
-			}
+		if (perception.getFoodAt(MY_POSITION) > 0) {
+			memory.put("pheromoneType", PheromoneType.FOOD);
+			memory.put("pheromoneDistance", new Integer(0));
+			return this.operationalBehaviour.pickFood(perception);
+		}
+		if (perception.isAvailableFoodInSight()) {
 			return this.operationalBehaviour.moveToTarget(perception, memory, perception.getClosestAvailableFoodPos());
 		}
 		Point highestFoodPheromonePos = perception.getHighestPheromonePos(PheromoneType.FOOD);

--- a/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/EnvironmentUtils.java
+++ b/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/EnvironmentUtils.java
@@ -81,12 +81,12 @@ public class EnvironmentUtils {
 						antHillCell = true;
 					}
 				}
-				// if there is an ant hill, there is not other objects on the
-				// cell
+				// if there is an ant hill, there should not be any other
+				// objects on the cell
 				if (!antHillCell) {
-					final float perlinHeight = randomFoodGrid.get(position).floatValue();
-					if (perlinHeight > 0.0f) {
-						envCell.addEnvObject(new Food(position, (int) perlinHeight));
+					final int perlinHeight = randomFoodGrid.get(position).intValue();
+					if (perlinHeight > 0) {
+						envCell.addEnvObject(new Food(position, perlinHeight));
 					}
 				}
 			}

--- a/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/envobject/AntHill.java
+++ b/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/envobject/AntHill.java
@@ -12,7 +12,7 @@ import fr.utbm.info.vi51.worldswar.utils.Stock;
 public class AntHill extends StaticObject {
 
 	/** Number of steps between the spawn of two ants in the anthill */
-	public static final int SPAWN_COOLDOWN = 5;
+	public static final int SPAWN_COOLDOWN = 15;
 	/** Food consumed by the spawn of a new ant */
 	public static final int SPAWN_COST = 25;
 

--- a/src/main/sarl/fr/utbm/info/vi51/worldswar/perception/AntPerception.java
+++ b/src/main/sarl/fr/utbm/info/vi51/worldswar/perception/AntPerception.java
@@ -137,9 +137,9 @@ public class AntPerception {
 	/**
 	 * @return {@code true} if there is available food in the ant's field of
 	 *         perception
-	 * @see AntPerception#getNearestAvailableFoodPos
+	 * @see AntPerception#getClosestAvailableFoodPos
 	 */
-	public boolean isFoodInSight() {
+	public boolean isAvailableFoodInSight() {
 		return this.getClosestAvailableFoodPos() != null;
 	}
 


### PR DESCRIPTION
Il y avait 2 problèmes : 
- Une fourmi sur une case peut ne pas voir de food disponible à proximité, puisqu'elle est dessus (et du coup la rend indisponible...)
- A la génération de la map, la conversion du bruit de perlin en float vers une qté de bouffe en int créait des objets food qui contenaient 0 de nourriture
