### PR TITLE
Fix crash when receiving an influence from an agent of a previous env…

### DIFF
--- a/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/Environment.sarl
+++ b/src/main/sarl/fr/utbm/info/vi51/worldswar/environment/Environment.sarl
@@ -185,7 +185,10 @@ agent Environment {
 	 */
 	on InfluenceEvent {
 		synchronized(this) {
-			var body = agentBodies.get(occurrence.uuid);
+			var body = agentBodies.get(occurrence.uuid)
+			if(body === null) {
+				warning("Influence received from agent #" + occurrence.uuid + ", but this agent does not exist in the current Environment.")
+			}
 			
 			if(body.influence !== null) {
 				error("Agent #" + occurrence.uuid + " has sent multiple influences in the same step")


### PR DESCRIPTION
Voir #60
Je ne règle pas tout le problème, mais quand des influences de la simulation précédente sont reçues, il y aura juste un warning au lieu de tout faire planter.
